### PR TITLE
Remove null player check on PlayersTeleportBackLocation - This is always...

### DIFF
--- a/src/main/java/net/cubespace/geSuit/listeners/TeleportsMessageListener.java
+++ b/src/main/java/net/cubespace/geSuit/listeners/TeleportsMessageListener.java
@@ -52,7 +52,7 @@ public class TeleportsMessageListener implements Listener {
         }
 
         if (task.equals("PlayersTeleportBackLocation")) {
-            GSPlayer player = PlayerManager.getPlayer(in.readUTF(), true);
+            GSPlayer player = PlayerManager.getPlayer(in.readUTF());
             if (player != null) {
             	TeleportManager.setPlayersTeleportBackLocation(player, new Location(((Server) event.getSender()).getInfo(), in.readUTF(), in.readDouble(), in.readDouble(), in.readDouble(), in.readFloat(), in.readFloat()));
             }


### PR DESCRIPTION
... null when the player disconnects from proxy, so it gets spammy
